### PR TITLE
feat(i18n): add debt-related translations for multiple languages

### DIFF
--- a/src/components/bill/BillDebt80.js
+++ b/src/components/bill/BillDebt80.js
@@ -31,18 +31,9 @@ export default function BillDebt80({
         }}
       >
         <div className="text-center mb-4">
-          {storeDetail?.image && (
-            <div className="mb-3 flex justify-center">
-              <img
-                src={storeDetail.image}
-                alt="Store Logo"
-                style={{ width: '60px', height: '60px', objectFit: 'contain' }}
-              />
-            </div>
-          )}
-          <div className="font-bold text-lg text-center w-full">{storeDetail?.name || 'Store Name'}</div>
+          <div className="font-bold text-lg justify-center item-center w-full">{storeDetail?.name || 'Store Name'}</div>
           {storeDetail?.phone && (
-            <div className="text-sm mt-1 text-center w-full">{t('phone')}: {storeDetail.phone}</div>
+            <div className="text-sm mt-1 justify-center item-center w-full">{t('phone')}: {storeDetail.phone}</div>
           )}
         </div>
         <div className="w-full pr-3">
@@ -68,11 +59,11 @@ export default function BillDebt80({
             <span>{billDebtData?.code}</span>
           </InfoRow>
           <InfoRow>
-            <span>{t('start_date') || 'Start Date'}:</span>
+            <span>{t('start_date_debt') || 'Start Date Debt'}:</span>
             <span>{formatDate(billDebtData?.startDate || new Date())}</span>
           </InfoRow>
           <InfoRow>
-            <span>{t('end_date') || 'End Date'}:</span>
+            <span>{t('end_date_debt') || 'End Date Debt'}:</span>
             <span>{formatDate(billDebtData?.endDate || new Date())}</span>
           </InfoRow>
           <InfoRow>
@@ -115,33 +106,23 @@ export default function BillDebt80({
       {/* <hr className="w-full border-b border-dotted border-black pr-2 py-4"/> */}
       <div className="mb-4 w-full pr-2">
         <InfoRow>
-          <span>{t('original_amount') || 'Original Amount'}:</span>
+          <span>{t('bill_debt_amount') || 'Original Amount'}:</span>
           <span>{moneyCurrency(billDebtData?.amount || 0)} {storeDetail?.firstCurrency}</span>
         </InfoRow>
 
         <InfoRow>
-          <span>{t('paid_amount') || 'Paid Amount'}:</span>
+          <span>{t('bill_debt_payment') || 'Paid Amount'}:</span>
           <span>{moneyCurrency(billDebtData?.payAmount || 0)} {storeDetail?.firstCurrency}</span>
         </InfoRow>
 
         <InfoRow className="font-bold">
-          <span>{t('remaining_amount') || 'Remaining Amount'}:</span>
+          <span>{t('bill_debt_remaining') || 'Remaining Amount'}:</span>
           <span>{moneyCurrency(billDebtData?.remainingAmount || (billDebtData?.originalAmount - billDebtData?.paidAmount) || 0)} {storeDetail?.firstCurrency}</span>
         </InfoRow>
       </div>
-      <div className="w-full pr-3">
-        <hr style={{ borderBottom: "1px dotted #000", width: "100%" }} />
-      </div>
-      {/* QR Code (if available) */}
-      {storeDetail?.printer?.qr && (
-        <div className="flex justify-center text-center mt-4">
-          <img
-            src={`https://app-api.appzap.la/qr-gennerate/qr?data=${storeDetail.printer.qr}`}
-            style={{ width: '100px', height: '100px' }}
-            alt="QR Code"
-          />
-        </div>
-      )}
+      
+      
+      
     </Container>
   )
 }

--- a/src/components/bill/BillForCheckOut80.js
+++ b/src/components/bill/BillForCheckOut80.js
@@ -55,7 +55,9 @@ export default function BillForCheckOut80({
   const serviceChargeRef = useRef(serviceCharge);
   const enableServiceChangeRef = useRef(enableServiceChange);
 
-  console.log("serviceCharge", serviceCharge);
+  console.log("serviceCharge11", serviceCharge);
+  console.log("dataBill22", dataBill);
+
 
   const orders =
     orderPayBefore && orderPayBefore.length > 0
@@ -93,7 +95,7 @@ export default function BillForCheckOut80({
       enableServiceChangeRef.current === true
     ) {
       return serviceChargeRef.current || 0;
-    } else {
+    } else if  (dataBill?.serviceChargeManual) {
       return serviceCharge;
     }
 

--- a/src/i18n/en_KM.json
+++ b/src/i18n/en_KM.json
@@ -1289,5 +1289,10 @@
   "print_bill_to_kitcher":"បោះពុម្ពវិក្កយបត្រទៅងាយ",
   "print_bill_sticker":"បោះពុម្ពស្តុកផ្ទាល់ខ្លួន",
   "counter_menu_management":"ការគ្រប់គ្រងម៉ឺនុយក្នុងការគ្រប់គ្រង",
-  "disable_menu_pricing": "បិទការគ្រប់គ្រងតម្លៃម៉ឺនុយ"
+  "disable_menu_pricing": "បិទការគ្រប់គ្រងតម្លៃម៉ឺនុយ",
+  "bill_debt": "ការគ្រប់គ្រងតម្លៃ",
+  "bill_debt_amount": "ចំនួនទឹកប្រាក់ការគ្រប់គ្រង",
+  "bill_debt_payment": "ចំនួនទឹកប្រាក់ដែលបានទទួល",
+  "bill_debt_remaining": "ចំនួនទឹកប្រាក់ដែលមិនបានទទួល",
+  "bill_debt_paid": "ចំនួនទឹកប្រាក់ដែលបានទទួល"
 }

--- a/src/i18n/en_LA.json
+++ b/src/i18n/en_LA.json
@@ -1425,5 +1425,10 @@
   "print_bill_to_kitcher":"ພີມບີນໄປຄົວ",
   "print_bill_sticker":"ພີມ sticker",
   "counter_menu_management":"counter ຈັດການເມນູ",
-  "disable_menu_pricing": "ປິດລາຄາອໍເດີ"
+  "disable_menu_pricing": "ປິດລາຄາອໍເດີ",
+  "bill_debt": "ບີນຕິດໝີ້",
+  "bill_debt_amount": "ຕິດໝີ້ຈຳນວນເງິນ",
+  "bill_debt_payment": "ເງິນເອົາ",
+  "bill_debt_remaining": "ເງິນຕິດໝີ້ທີ່ຍັງເຫຼືອ",
+  "bill_debt_paid": "ເງິນທີ່ຈ່າຍແລ້ວ"
 }

--- a/src/i18n/en_TH.json
+++ b/src/i18n/en_TH.json
@@ -1295,5 +1295,10 @@
   "print_bill_to_kitcher":"พิมพ์บิลไปครัว",
   "print_bill_sticker":"พิมพ์สแตกเตอร์",
   "counter_menu_management":"counnter การจัดการเมนู",
-  "disable_menu_pricing": "ปิดการจัดการราคาสินค้า"
+  "disable_menu_pricing": "ปิดการจัดการราคาสินค้า",
+  "bill_debt": "ติดดอกเบี้ย",
+  "bill_debt_amount": "จำนวนเงินติดดอกเบี้ย",
+  "bill_debt_payment": "จำนวนเงินที่ชำระ",
+  "bill_debt_remaining": "จำนวนเงินติดดอกเบี้ยที่ยังไม่ชำระ",
+  "bill_debt_paid": "จำนวนเงินที่ชำระแล้ว"
 }

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -1425,5 +1425,10 @@
   "print_bill_to_kitcher":"Print bill to kitchen",
   "print_bill_sticker":"Print sticker",
   "counter_menu_management":"Counter menu management",
-  "disable_menu_pricing": "Disable menu pricing"
+  "disable_menu_pricing": "Disable menu pricing",
+  "bill_debt": "Bill debt",
+  "bill_debt_amount": "Bill debt amount",
+  "bill_debt_payment": "Bill debt payment",
+  "bill_debt_remaining": "Bill debt remaining",
+  "bill_debt_paid": "Bill debt paid"
 }

--- a/src/pages/table/TableList.js
+++ b/src/pages/table/TableList.js
@@ -272,6 +272,8 @@ export default function TableList() {
     }, {});
   };
 
+  console.log("serviceChargePercent", serviceChargePercent);
+
   useEffect(() => {
     if (!pinStatus) return;
     setPinStatus(false);


### PR DESCRIPTION
Add new translation keys for debt management in en_US, en_LA, en_TH, and en_KM Refactor BillDebt80 component to use new translation keys and remove QR code Update BillForCheckOut80 with additional debug logs and service charge logic